### PR TITLE
Import `Iterable` from `collections` is deprecated 

### DIFF
--- a/iterwrapper/wrapper.py
+++ b/iterwrapper/wrapper.py
@@ -1,5 +1,5 @@
-from collections import Iterable as _Iterable
-from collections import Callable as _Callable
+from collections.abc import Iterable as _Iterable
+from collections.abc import Callable as _Callable
 from iterwrapper.misc import all_eq, tail_inf
 
 


### PR DESCRIPTION
Import `Iterable` from `collections` is deprecated since Python 3.3 and it won't work after Python 3.10.